### PR TITLE
Adding publicDeltaCore env var to frontend

### DIFF
--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -31,7 +31,7 @@ services:
     environment:
       - NODE_ENV=development
       - DELTA_CORE_URL=http://delta_core:5000
-      - PUBLIC_DELTA_CORE_URL=https://delta-reporter.dsch.dev/
+      - PUBLIC_DELTA_CORE_URL=http://localhost:5000
     links:
       - delta_core
 

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -31,6 +31,7 @@ services:
     environment:
       - NODE_ENV=development
       - DELTA_CORE_URL=http://delta_core:5000
+      - PUBLIC_DELTA_CORE_URL=https://delta-reporter.dsch.dev/
     links:
       - delta_core
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       - '3000:3000'
     environment:
       - DELTA_CORE_URL=http://delta_core:5000
-      - PUBLIC_DELTA_CORE_URL=https://delta-reporter.dsch.dev/
+      - PUBLIC_DELTA_CORE_URL=http://localhost:5000
       - PORT=3000
     links:
       - delta_core

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,7 @@ services:
       - '3000:3000'
     environment:
       - DELTA_CORE_URL=http://delta_core:5000
+      - PUBLIC_DELTA_CORE_URL=https://delta-reporter.dsch.dev/
       - PORT=3000
     links:
       - delta_core


### PR DESCRIPTION
not sure if that's correct, but adding PUBLIC_DELTA_CORE_URL to both dev and prod docker-compose